### PR TITLE
add OSS_FROM_EMAIL environmental variable to specify sender email address

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,10 @@ OSS_AWS_SECRET_KEY=[Your AWS Secret Key if you run app out of AWS]
 ```
 OSS_SMTP_SERVER=[Your SMTP server]
 OSS_SMTP_PORT=[587]
-OSS_SMTP_USERNAME=[Your email address]
-OSS_SMTP_PASSWORD=[Your SMTP Password]
+OSS_SMTP_USERNAME=[Your SMTP account]
+OSS_SMTP_PASSWORD=[Your SMTP password]
 OSS_SMTP_AUTH_METHOD=plain
+OSS_FROM_EMAIL=[Email address that will be used sender]
 OSS_SECRET_KEY_BASE=[Your Secret Key Base]
 OSS_PRODUCTION_HOST=[hoge.example.com]
 OSS_ROOT_URL=[http://your_root_url]

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,7 +12,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = ENV['OSS_FROM_EMAIL'] || ENV['OSS_SMTP_USERNAME'] || 'info@example.com'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
- use ENV['OSS_FROM_EMAIL'] as sender email address
- if you do not specify this environmental variable, ENV['OSS_SMTP_USER'] as sender.
- if these 2 variables are not set, sender will be info@example.com